### PR TITLE
Fix to work with MediaWiki >= 1.29

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,10 @@
+{
+	"extends": "wikimedia",
+	"env": {
+		"browser": true
+	},
+	"globals": {
+		"mw": false,
+		"$": false
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.*.swp
+*~
+/.project
+/composer.lock
+/vendor
+/node_modules
+/package-lock.json

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Squiz.Scope.MethodScope.Missing" />
+	</rule>
+	<file>.</file>
+	<arg name="extensions" value="php,php5,inc" />
+	<arg name="encoding" value="utf8" />
+	<exclude-pattern>vendor</exclude-pattern>
+</ruleset>

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+	"extends": "stylelint-config-wikimedia"
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,33 @@
+/* eslint-env node */
+module.exports = function ( grunt ) {
+	var conf = grunt.file.readJSON( 'extension.json' );
+
+	grunt.loadNpmTasks( 'grunt-banana-checker' );
+	grunt.loadNpmTasks( 'grunt-eslint' );
+	grunt.loadNpmTasks( 'grunt-jsonlint' );
+	grunt.loadNpmTasks( 'grunt-stylelint' );
+
+	grunt.initConfig( {
+		eslint: {
+			all: '.'
+		},
+		jsonlint: {
+			all: [
+				'**/*.json',
+				'!node_modules/**',
+				'!vendor/**'
+			]
+		},
+		stylelint: {
+			all: [
+				'**/*.{css,less}',
+				'!node_modules/**',
+				'!vendor/**'
+			]
+		},
+		banana: conf.MessagesDirs
+	} );
+
+	grunt.registerTask( 'test', [ 'eslint', 'stylelint', 'jsonlint' ] );
+	grunt.registerTask( 'default', 'test' );
+};

--- a/MoveToSkin.i18n.magic.php
+++ b/MoveToSkin.i18n.magic.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Internationalisation file for extension MoveToSkin.
+ *
+ * @file
+ * @ingroup Extensions
+ * @author Dror S.
+ */
+
+$magicWords = [];
+
+/** English (English) */
+$magicWords['en'] = [
+	'movetoskin' => [ 0, 'movetoskin' ],
+];

--- a/MoveToSkin.php
+++ b/MoveToSkin.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * MoveToSkin
- * A simple plugin which allows you to move content from a wiki article 
+ * A simple plugin which allows you to move content from a wiki article
  * to predefined areas in your skin.
  * Intended for MediaWiki Skin designers.
  * By Andru Vallance - andru@tinymighty.com
@@ -10,103 +10,67 @@
  *
  */
 
-$wgHooks['ParserFirstCallInit'][] = 'MoveToSkin::parserFirstCallInit';
-$wgHooks['LanguageGetMagic'][] = 'MoveToSkin::languageGetMagic';
-/* This was hooked to ParserAfterTidy, but that isn't called when the parse skep
-is skipped by retrieving from the parser cache */
-$wgHooks['OutputPageBeforeHTML'][] = 'MoveToSkin::moveContent';
+class MoveToSkin {
 
-$wgExtensionCredits['parserhook'][] = array(
-   'path' => __FILE__,
-   'name' => 'Move To Skin',
-   'description' => 'Move content from the article to the skin.',
-   'version' => '0.1.2', 
-   'author' => 'Andru Vallance',
-   'url' => 'https://www.mediawiki.org/wiki/Extension:MoveToSkin'
-);
+	public static $content = array();
 
-class MoveToSkin{
-  
-  public static $content = array();
-  
-  public static function parserFirstCallInit(&$parser){
-    $parser->setFunctionHook('movetoskin', 'MoveToSkin::parserFunction');
-    return true;
-  }
-  
-  public static function languageGetMagic(&$magicWords){
-    $magicWords['movetoskin'] = array(0,'movetoskin');
-    return true;
-  }
-  
-  public static function parserFunction($parser, $name='', $content=''){
-    //we have to wrap the inner content within <p> tags, because MW screws up otherwise by placing a <p> tag before and after with related closing and opening tags within
-    //php's DOM library doesn't like that and will swap the order of the first closing </p> and the closing </movetoskin> - stranding everything after that outside the <movetoskin> block. Lame.
-    //$content = $parser->recursiveTagParse($content);
-    $content = '<div class="movetoskin" data-target="'.$name.'">'.$content.'</div>';
-    return array( $content, 'noparse' => false, 'isHTML' => false );
-  }
-  
-  public static function moveContent(&$out, &$html){
-   if(empty($html))
-     return true;
-    //not sure why, but we have to UTF8 decode the html output... DOM Document is UTF8, so not sure why this is necessary, but without it UTF8 entities are garbled
-    $html = utf8_decode($html);
-    $doc = @DOMDocument::loadHTML( $html );
-    //$doc->encoding = 'utf8';
-    $xpath = new DomXPath($doc);
-    $nodes = $xpath->query("//*[contains(concat(' ', normalize-space(@class), ' '), ' movetoskin ')]");
-    //$movetoskins = $doc->getElementsByTagName('movetoskin');
-    
-    if($nodes->length > 0){
-      foreach($nodes as $move){
-        if($move->hasAttribute('data-target')){
-          $target = $move->getAttribute('data-target');
-          $inner_content = '';
-          
-          $move->removeAttribute('class');
-          $move->removeAttribute('data-target');
-          
-          $inner_content = trim($doc->saveHTML( $move ));
-          //chop off the starting <div> and ending </div> ... it's easier than trying to grab the contents via dom
-          $inner_content = substr($inner_content, 5, count($inner_content)-7);
-                    
-          if(isset( self::$content[ $target ] )){
-            array_push( self::$content[ $target ] , $inner_content );
-          }else{
-            self::$content[ $target ] = array(
-              $inner_content 
-            );
-          }
-          $parent = $move->parentNode;
-          $parent->removeChild($move);
-        }
-      }
-      
-      $htmldoc = $doc->saveHTML( $doc->getElementsByTagName('body')->item(0) );
-      if(preg_match('~<body>(.*?)<\/body>~si', $htmldoc, $match)){
-        $html = $match[1];
-      }
-      $html = $html;
-    }
+	public static function parserFirstCallInit( Parser &$parser ) {
+		$parser->setFunctionHook( 'movetoskin', 'MoveToSkin::parserFunction' );
 
-    return true;
-  }
-    
-  public static function hasContent($target){
-    if(isset(self::$content[$target]))
-      return true;
-    return false;
-  }
-  
-  public static function getContent($target=null){
-    if($target!==null){
-      if( self::hasContent($target) )
-        return self::$content[$target];
-      return array();
-    }else{
-      return self::$content;
-    }
-  }
+		return true;
+	}
+
+	public static function languageGetMagic( &$magicWords ) {
+		$magicWords[ 'movetoskin' ] = array( 0, 'movetoskin' );
+
+		return true;
+	}
+
+	public static function parserFunction( $parser, $name = '', $content = '' ) {
+		// we have to wrap the inner content within <p> tags, because MW screws up otherwise by
+		// placing a <p> tag before and after with related closing and opening tags within php's
+		// DOM library doesn't like that and will swap the order of the first closing </p> and the
+		// closing </movetoskin> - stranding everything after that outside the <movetoskin> block. Lame.
+		// $content = $parser->recursiveTagParse($content);
+		$content = '<ins data-type="movetoskin" data-name="' . $name . '">' . $content . '</ins>';
+
+		return [ $content, 'noparse' => false, 'isHTML' => false ];
+	}
+
+	public static function moveContent( &$out, &$html ) {
+		if ( empty( $html ) ) {
+			return $html;
+		}
+		if ( preg_match_all( '~<ins data-type="movetoskin" data-name="([\w:-]+)">([\S\s]*?)<\/ins>~m', $html, $matches, PREG_SET_ORDER ) ) {
+			foreach ( $matches as $match ) {
+				if ( !isset( self::$content[ $match[1] ] ) ) {
+					self::$content[ $match[1] ] = [];
+				}
+				array_push( self::$content[ $match[1] ], $match[2] );
+				$html = str_replace( $match[0], '', $html );
+			}
+		}
+		return true;
+	}
+
+	public static function hasContent( $target ) {
+		if ( isset( self::$content[ $target ] ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public static function getContent( $target = null ) {
+		if ( $target !== null ) {
+			if ( self::hasContent( $target ) ) {
+				return self::$content[ $target ];
+			}
+
+			return array();
+		} else {
+			return self::$content;
+		}
+	}
 
 }

--- a/MoveToSkin.php
+++ b/MoveToSkin.php
@@ -12,20 +12,38 @@
 
 class MoveToSkin {
 
-	public static $content = array();
+	public static $content = [];
 
+	/**
+	 * @param Parser &$parser
+	 *
+	 * @return bool
+	 * @throws MWException
+	 */
 	public static function parserFirstCallInit( Parser &$parser ) {
 		$parser->setFunctionHook( 'movetoskin', 'MoveToSkin::parserFunction' );
 
 		return true;
 	}
 
+	/**
+	 * @param array &$magicWords
+	 *
+	 * @return bool
+	 */
 	public static function languageGetMagic( &$magicWords ) {
-		$magicWords[ 'movetoskin' ] = array( 0, 'movetoskin' );
+		$magicWords[ 'movetoskin' ] = [ 0, 'movetoskin' ];
 
 		return true;
 	}
 
+	/**
+	 * @param Parser $parser
+	 * @param string $name
+	 * @param string $content
+	 *
+	 * @return array
+	 */
 	public static function parserFunction( $parser, $name = '', $content = '' ) {
 		// we have to wrap the inner content within <p> tags, because MW screws up otherwise by
 		// placing a <p> tag before and after with related closing and opening tags within php's
@@ -37,11 +55,19 @@ class MoveToSkin {
 		return [ $content, 'noparse' => false, 'isHTML' => false ];
 	}
 
-	public static function moveContent( &$out, &$html ) {
-		if ( empty( $html ) ) {
-			return $html;
-		}
-		if ( preg_match_all( '~<ins data-type="movetoskin" data-name="([\w:-]+)">([\S\s]*?)<\/ins>~m', $html, $matches, PREG_SET_ORDER ) ) {
+	/**
+	 * @param OutputPage &$out
+	 * @param string &$html
+	 *
+	 * @return null
+	 */
+	public static function moveContent( OutputPage &$out, &$html ) {
+		if ( !empty( $html ) &&
+			 preg_match_all(
+				'~<ins data-type="movetoskin" data-name="([\w:-]+)">([\S\s]*?)<\/ins>~m',
+				$html, $matches, PREG_SET_ORDER
+			 )
+		) {
 			foreach ( $matches as $match ) {
 				if ( !isset( self::$content[ $match[1] ] ) ) {
 					self::$content[ $match[1] ] = [];
@@ -50,9 +76,14 @@ class MoveToSkin {
 				$html = str_replace( $match[0], '', $html );
 			}
 		}
-		return true;
+		return null;
 	}
 
+	/**
+	 * @param string $target
+	 *
+	 * @return bool
+	 */
 	public static function hasContent( $target ) {
 		if ( isset( self::$content[ $target ] ) ) {
 			return true;
@@ -61,13 +92,18 @@ class MoveToSkin {
 		return false;
 	}
 
+	/**
+	 * @param null $target
+	 *
+	 * @return array|mixed
+	 */
 	public static function getContent( $target = null ) {
 		if ( $target !== null ) {
 			if ( self::hasContent( $target ) ) {
 				return self::$content[ $target ];
 			}
 
-			return array();
+			return [];
 		} else {
 			return self::$content;
 		}

--- a/MoveToSkin.php
+++ b/MoveToSkin.php
@@ -17,24 +17,10 @@ class MoveToSkin {
 	/**
 	 * @param Parser &$parser
 	 *
-	 * @return bool
 	 * @throws MWException
 	 */
-	public static function parserFirstCallInit( Parser &$parser ) {
+	public static function onParserFirstCallInit( Parser &$parser ) {
 		$parser->setFunctionHook( 'movetoskin', 'MoveToSkin::parserFunction' );
-
-		return true;
-	}
-
-	/**
-	 * @param array &$magicWords
-	 *
-	 * @return bool
-	 */
-	public static function languageGetMagic( &$magicWords ) {
-		$magicWords[ 'movetoskin' ] = [ 0, 'movetoskin' ];
-
-		return true;
 	}
 
 	/**
@@ -56,12 +42,12 @@ class MoveToSkin {
 	}
 
 	/**
+	 * Move content
+	 *
 	 * @param OutputPage &$out
 	 * @param string &$html
-	 *
-	 * @return null
 	 */
-	public static function moveContent( OutputPage &$out, &$html ) {
+	public static function onOutputPageBeforeHTML( OutputPage &$out, &$html ) {
 		if ( !empty( $html ) &&
 			 preg_match_all(
 				'~<ins data-type="movetoskin" data-name="([\w:-]+)">([\S\s]*?)<\/ins>~m',
@@ -76,7 +62,6 @@ class MoveToSkin {
 				$html = str_replace( $match[0], '', $html );
 			}
 		}
-		return null;
 	}
 
 	/**

--- a/README.md
+++ b/README.md
@@ -1,24 +1,29 @@
-#Move To Skin (MediaWiki Extension)#
-====================
+Move To Skin (MediaWiki Extension)
+==================================
 
-A MediaWiki extension which allows article content to be moved to the skin. Useful for skin designers looking for a way to have control over their skin from a wiki article without resorting to Javascript hacks.
+A MediaWiki extension which allows article content to be moved to the
+skin. Useful for skin designers looking for a way to have control over
+their skin from a wiki article without resorting to Javascript hacks.
 
-Copy to extensions and include MoveToSkin.php in LocalSettings in the usual way.
+## Usage in a wiki article
+In your articles, use the parser function `{{#movetoskin:target|content}}`.
+* The first argument, *target*, is a unique name you can use in the skin
+  to show this content.
+* The second argument, *content*, is the content you want to move.
 
-##Usage in a wiki article##
-In your articles, use the parser function {{#movetoskin:target|content}}.
-* The first argument, *target* is a unique name you can use in the skin to show this content.
-* The second argument *content* is the content you want to move.
 You can use the same target mutiple times.
 
-##Usage in the skin##
-Use the static method MoveToSkin::getContent() in your skin to grab an array of all the content, indexed by target name. You can then use this to output the content wherever you choose.
+## Usage in a skin
+Use the static method `MoveToSkin::getContent()` in your skin to grab an
+array of all the content, indexed by target name. You can then use this
+to output the content wherever you choose.
 
-Eg.
-
-	$content = MoveToSkin::getContent();
-	if(isset($content['target name'])){
-		foreach($content['target name'] as $c){
-			echo '<div class="something">'.$c.'</div>';
-		}
-	}
+Example for usage in skin:
+```php
+$content = MoveToSkin::getContent();
+if ( isset( $content['target name'] ) ) {
+    foreach ( $content['target name'] as $c ){
+        echo '<div class="something">'.$c.'</div>';
+    }
+}
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,19 @@
+{
+	"require-dev": {
+		"jakub-onderka/php-parallel-lint": "1.0.0",
+		"mediawiki/mediawiki-codesniffer": "23.0.0",
+		"jakub-onderka/php-console-highlighter": "0.3.2",
+		"mediawiki/minus-x": "0.3.1"
+	},
+	"scripts": {
+		"test": [
+			"parallel-lint . --exclude vendor --exclude node_modules",
+			"phpcs -p -s",
+			"minus-x check ."
+		],
+		"fix": [
+			"minus-x fix .",
+			"phpcbf"
+		]
+	}
+}

--- a/extension.json
+++ b/extension.json
@@ -9,9 +9,11 @@
 		"MoveToSkin": "MoveToSkin.php"
 	},
 	"Hooks": {
-		"ParserFirstCallInit": "MoveToSkin::parserFirstCallInit",
-		"LanguageGetMagic": "MoveToSkin::languageGetMagic",
-		"OutputPageBeforeHTML": "MoveToSkin::moveContent"
+		"ParserFirstCallInit": "MoveToSkin::onParserFirstCallInit",
+		"OutputPageBeforeHTML": "MoveToSkin::onOutputPageBeforeHTML"
+	},
+	"ExtensionMessagesFiles": {
+		"MoveToSkinMagic": "MoveToSkin.i18n.magic.php"
 	},
 	"manifest_version": 2
 }

--- a/extension.json
+++ b/extension.json
@@ -1,0 +1,17 @@
+{
+	"name": "Move To Skin",
+	"version": "0.2",
+	"author": "Andru Vallance",
+	"url": "https://www.mediawiki.org/wiki/Extension:MoveToSkin",
+	"description": "Move content from the article to the skin.",
+	"type": "parserhook",
+	"AutoloadClasses": {
+		"MoveToSkin": "MoveToSkin.php"
+	},
+	"Hooks": {
+		"ParserFirstCallInit": "MoveToSkin::parserFirstCallInit",
+		"LanguageGetMagic": "MoveToSkin::languageGetMagic",
+		"OutputPageBeforeHTML": "MoveToSkin::moveContent"
+	},
+	"manifest_version": 2
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "scripts": {
+    "test": "grunt test"
+  },
+  "devDependencies": {
+    "eslint-config-wikimedia": "0.8.1",
+    "grunt": "1.0.3",
+    "grunt-banana-checker": "0.6.0",
+    "grunt-eslint": "21.0.0",
+    "grunt-jsonlint": "1.1.0",
+    "grunt-stylelint": "0.10.1",
+    "stylelint": "9.2.0",
+    "stylelint-config-wikimedia": "0.4.3"
+  },
+  "eslintIgnore": [
+    "vendor/**"
+  ]
+}


### PR DESCRIPTION
This mainly involves copying slightly more up-to-date code from
extension:Skinny.

Additional changes:
- Convert to extension registration
- Beautify code according to MW standards